### PR TITLE
Native functions can be used from the handle instance

### DIFF
--- a/Src/LuaFunctions.cpp
+++ b/Src/LuaFunctions.cpp
@@ -6,6 +6,7 @@
 #include "EasyStormLib/EasyStormLib.h"
 
 #define lua_registerJassNative(L, n, c, f) (lua_pushstring(L, (n)), lua_pushinteger(L, (DWORD)(c)), lua_pushcclosure(L, (f), 2), lua_setglobal(L, (n)))
+#define lua_pushJassNative(L, n, c, f) (lua_pushstring(L, (n)), lua_pushinteger(L, (DWORD)(c)), lua_pushcclosure(L, (f), 2))
 
 std::map<std::string, bool> destroyers = {
 	{"DestroyTimer", true},
@@ -407,6 +408,24 @@ namespace LuaFunctions {
 
 				lua_pushboolean(l, false);
 				lua_setfield(l, -2, "__metatable");
+
+				// Collect natives with the corresponding first argument
+
+				lua_newtable(l);
+
+				for (auto& native : Jass::jassnatives) {
+					if (!native.second.GetParams().empty()) {
+
+						std::string firstArgType = native.second.GetParams()[0];
+						
+						if (IsChild(firstArgType, type.first)) {
+							lua_pushJassNative(l, native.first.c_str(), &native.second, lua_invokeNative);
+							lua_setfield(l, -2, native.first.c_str());
+						}
+					}
+				}
+
+				lua_setfield(l, -2, "__index");
 
 				lua_pop(l, 1);
 			}


### PR DESCRIPTION
Разрешает обращаться в режиме Read Only к userdata, как к таблице. В таблице сгруппированы все нативки, которые первым параметром принимают соответствующий тип указателя (или родительский тип). В таблицу нельзя записывать свои поля.

```
Player(0):CreateUnit(FourCC("Hpal"), 0, 0, 0):KillUnit();
```